### PR TITLE
chore(lint): enable IDE linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  "extends": [
+    "react-app",
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended"
+  ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^16.13.1",
     "tsdx": "^0.13.3",
     "tslib": "^2.0.1",
-    "typescript": "^4.0.2"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "zustand": "^3.1.1"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,11 @@ export default function create<TState>(
   const useZStore: UseStore<StateInValue<TState>> = zcreate(() => ({}));
   const reactRoot = document.createElement('div');
   ReactDOM.render(
-    <StoreComponent<TState> hook={hook} hookArgs={hookArgs} useZStore={useZStore} />,
+    <StoreComponent<TState>
+      hook={hook}
+      hookArgs={hookArgs}
+      useZStore={useZStore}
+    />,
     reactRoot
   );
   function internalSelector<U>(selector?: StateSelector<TState, U>) {

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -222,7 +222,7 @@ describe('create', () => {
     expect(screen.getByRole('heading').textContent).toEqual(
       'Welcome to the future, React Devs'
     );
-  })
+  });
 
   test('composition 2', async () => {
     const useMsg = () => {
@@ -232,7 +232,13 @@ describe('create', () => {
       return useState('Tim');
     };
 
-    type useWelcomeMsgState = { welcomeMsg: string, msg: string, name: string, setMsg: Function, setName: Function}
+    type useWelcomeMsgState = {
+      welcomeMsg: string;
+      msg: string;
+      name: string;
+      setMsg: Function;
+      setName: Function;
+    };
     const useWelcomeMsg = create<useWelcomeMsgState>(() => {
       const [msg, setMsg] = useMsg();
       const [name, setName] = useName();
@@ -250,7 +256,9 @@ describe('create', () => {
     };
 
     const Edit = () => {
-      const {msg, setMsg, name, setName} = useWelcomeMsg(({ welcomeMsg, ...rest }) => rest);
+      const { msg, setMsg, name, setName } = useWelcomeMsg(
+        ({ welcomeMsg, ...rest }) => rest
+      );
       return (
         <>
           <input
@@ -306,7 +314,7 @@ describe('create', () => {
     );
 
     act(() => {
-      const {setMsg, setName} = useWelcomeMsg.getState();
+      const { setMsg, setName } = useWelcomeMsg.getState();
       setMsg('Welcome to the future');
       setName('React Devs');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5919,15 +5919,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.7.3:
+typescript@^3.7.3, typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
-typescript@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This PR enables IDE linting by making the following changes:

- generated `.eslintrc.js` using `yarn lint --write-file`, which writes the internal `tsdx` config to the project (see formium/tsdx#354)
- downgraded `typescript` to `^typescript@3.9.7` for compatibility with `eslint` (see formium/tsdx#810)
	- this was causing lint failure due to `eslint` being unable to handle `typescript@4.0.2`
- fixed error reported by `prettier`