### PR TITLE
fix(ci): move --watch to separate test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
-    "test": "tsdx test --passWithNoTests --watch --env=jest-environment-jsdom-sixteen",
+    "test": "tsdx test --passWithNoTests --env=jest-environment-jsdom-sixteen",
+    "test:watch": "npm run test -- --watch",
     "lint": "tsdx lint",
     "prepare": "tsdx build"
   },


### PR DESCRIPTION
This change moves the `--watch` flag to `test:watch`, so that CI can reliably run `npm run test` without it hanging for 5 hours, 59 minutes, and 37 seconds before failing. 😁 